### PR TITLE
[SVD-4] CSV export of the day's log

### DIFF
--- a/lib/csv.js
+++ b/lib/csv.js
@@ -1,0 +1,96 @@
+'use strict';
+
+/**
+ * Minimal RFC 4180-compliant CSV utilities for the TideLog day-sheet export.
+ *
+ * Rules applied:
+ *  - Fields containing commas, double-quotes, or newlines are wrapped in
+ *    double-quotes.
+ *  - Double-quotes inside a quoted field are escaped by doubling them ("").
+ *  - All other fields are emitted as-is.
+ */
+
+/** CSV column headers for the arrivals day-sheet export. */
+const ARRIVALS_HEADERS = [
+  'id',
+  'vesselName',
+  'vesselType',
+  'lengthM',
+  'draftM',
+  'imo',
+  'eta',
+  'status',
+  'berthId',
+  'berthFrom',
+  'berthTo',
+  'loggedAt',
+  'arrivedAt',
+];
+
+/**
+ * Escape a single value for CSV output.
+ *
+ * @param {*} value - The raw value to escape.
+ * @returns {string} A safe CSV field string.
+ */
+function escapeCsvField(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  const str = String(value);
+  // Wrap in quotes if the value contains a comma, double-quote, or newline.
+  if (str.includes('"') || str.includes(',') || str.includes('\n') || str.includes('\r')) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+/**
+ * Serialize an array of field values into a single CSV row string (no trailing newline).
+ *
+ * @param {Array<*>} fields - The values for each column.
+ * @returns {string} A CSV row.
+ */
+function toCsvRow(fields) {
+  return fields.map(escapeCsvField).join(',');
+}
+
+/**
+ * Build a complete CSV document (headers + data rows) for a list of arrivals.
+ *
+ * Each arrival may carry an optional `berth` object (added by `withBerth`).
+ *
+ * @param {Array<object>} arrivals - Arrival objects, each optionally with a `berth` field.
+ * @returns {string} The full CSV text, lines separated by CRLF as per RFC 4180.
+ */
+function arrivalsToCsv(arrivals) {
+  const lines = [toCsvRow(ARRIVALS_HEADERS)];
+  for (const a of arrivals) {
+    const berth = a.berth || {};
+    lines.push(
+      toCsvRow([
+        a.id,
+        a.vesselName,
+        a.vesselType,
+        a.lengthM,
+        a.draftM,
+        a.imo,
+        a.eta,
+        a.status,
+        berth.berthId,
+        berth.from,
+        berth.to,
+        a.loggedAt,
+        a.arrivedAt,
+      ])
+    );
+  }
+  return lines.join('\r\n');
+}
+
+module.exports = {
+  ARRIVALS_HEADERS,
+  escapeCsvField,
+  toCsvRow,
+  arrivalsToCsv,
+};

--- a/routes/arrivals.js
+++ b/routes/arrivals.js
@@ -4,6 +4,7 @@ const express = require('express');
 
 const { normalizeManifest, VESSEL_TYPES } = require('../lib/manifest');
 const { findBerth } = require('../lib/berths');
+const { arrivalsToCsv } = require('../lib/csv');
 const db = require('./db');
 
 const router = express.Router();
@@ -41,6 +42,28 @@ router.get('/', (req, res) => {
   }
 
   res.json({ arrivals: arrivals.map(withBerth) });
+});
+
+/**
+ * Export the current arrival log as a CSV file for archiving.
+ *
+ * Returns one row per arrival with columns: id, vesselName, vesselType,
+ * lengthM, draftM, imo, eta, status, berthId, berthFrom, berthTo,
+ * loggedAt, arrivedAt.
+ *
+ * Responds with Content-Type: text/csv and a Content-Disposition header
+ * that suggests a dated filename so the harbor office can save the day sheet.
+ */
+router.get('/export.csv', (req, res) => {
+  const arrivals = [...db.state.arrivals.values()].map(withBerth);
+  const csv = arrivalsToCsv(arrivals);
+
+  const dateStamp = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  const filename = `arrivals-${dateStamp}.csv`;
+
+  res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+  res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+  res.send(csv);
 });
 
 /** Log a new expected arrival from a manifest. */

--- a/tests/csv.test.js
+++ b/tests/csv.test.js
@@ -1,0 +1,136 @@
+'use strict';
+
+const { escapeCsvField, toCsvRow, arrivalsToCsv, ARRIVALS_HEADERS } = require('../lib/csv');
+
+describe('escapeCsvField', () => {
+  test('returns an empty string for null and undefined', () => {
+    expect(escapeCsvField(null)).toBe('');
+    expect(escapeCsvField(undefined)).toBe('');
+  });
+
+  test('returns plain values unchanged', () => {
+    expect(escapeCsvField('hello')).toBe('hello');
+    expect(escapeCsvField(42)).toBe('42');
+    expect(escapeCsvField(3.14)).toBe('3.14');
+  });
+
+  test('wraps a field containing a comma in double-quotes', () => {
+    expect(escapeCsvField('hello, world')).toBe('"hello, world"');
+  });
+
+  test('wraps a field containing a double-quote and escapes it by doubling', () => {
+    expect(escapeCsvField('say "hi"')).toBe('"say ""hi"""');
+  });
+
+  test('wraps a field containing a newline', () => {
+    expect(escapeCsvField('line1\nline2')).toBe('"line1\nline2"');
+  });
+
+  test('wraps a field containing a carriage return', () => {
+    expect(escapeCsvField('line1\rline2')).toBe('"line1\rline2"');
+  });
+});
+
+describe('toCsvRow', () => {
+  test('joins plain fields with commas', () => {
+    expect(toCsvRow(['a', 'b', 'c'])).toBe('a,b,c');
+  });
+
+  test('correctly escapes a mixed row', () => {
+    expect(toCsvRow(['MV Northern Star', 'cargo', '85', null])).toBe('MV Northern Star,cargo,85,');
+  });
+
+  test('handles a vessel name that contains a comma', () => {
+    expect(toCsvRow(['Star, MV', 'cargo'])).toBe('"Star, MV",cargo');
+  });
+});
+
+describe('arrivalsToCsv', () => {
+  const baseArrival = {
+    id: 'ARR-001',
+    vesselName: 'MV Northern Star',
+    vesselType: 'cargo',
+    lengthM: 85,
+    draftM: 6.2,
+    imo: 'IMO 9319466',
+    eta: '2026-03-01T14:00:00.000Z',
+    status: 'expected',
+    berth: null,
+    loggedAt: '2026-03-01T04:00:00.000Z',
+    arrivedAt: undefined,
+  };
+
+  test('produces a header row followed by one data row', () => {
+    const csv = arrivalsToCsv([baseArrival]);
+    const lines = csv.split('\r\n');
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe(ARRIVALS_HEADERS.join(','));
+  });
+
+  test('header row contains exactly the expected column names', () => {
+    const csv = arrivalsToCsv([]);
+    const [header] = csv.split('\r\n');
+    expect(header).toBe(
+      'id,vesselName,vesselType,lengthM,draftM,imo,eta,status,berthId,berthFrom,berthTo,loggedAt,arrivedAt'
+    );
+  });
+
+  test('data row fields match the arrival values', () => {
+    const csv = arrivalsToCsv([baseArrival]);
+    const [, dataRow] = csv.split('\r\n');
+    expect(dataRow).toBe(
+      'ARR-001,MV Northern Star,cargo,85,6.2,IMO 9319466,2026-03-01T14:00:00.000Z,expected,,,,2026-03-01T04:00:00.000Z,'
+    );
+  });
+
+  test('emits berth columns when a berth assignment is present', () => {
+    const arrived = {
+      ...baseArrival,
+      status: 'arrived',
+      arrivedAt: '2026-03-01T15:30:00.000Z',
+      berth: {
+        berthId: 'B1',
+        from: '2026-03-01T14:00:00.000Z',
+        to: '2026-03-01T22:00:00.000Z',
+      },
+    };
+    const csv = arrivalsToCsv([arrived]);
+    const [, dataRow] = csv.split('\r\n');
+    expect(dataRow).toContain('B1');
+    expect(dataRow).toContain('2026-03-01T14:00:00.000Z');
+    expect(dataRow).toContain('2026-03-01T22:00:00.000Z');
+    expect(dataRow).toContain('2026-03-01T15:30:00.000Z');
+  });
+
+  test('returns only the header row when the log is empty', () => {
+    const csv = arrivalsToCsv([]);
+    expect(csv).toBe(ARRIVALS_HEADERS.join(','));
+  });
+
+  test('correctly escapes a vessel name that contains a comma', () => {
+    const tricky = {
+      ...baseArrival,
+      vesselName: 'Star, MV',
+    };
+    const csv = arrivalsToCsv([tricky]);
+    const [, dataRow] = csv.split('\r\n');
+    expect(dataRow).toMatch(/^ARR-001,"Star, MV",/);
+  });
+
+  test('correctly escapes a vessel name that contains a double-quote', () => {
+    const tricky = {
+      ...baseArrival,
+      vesselName: 'MV "Lucky"',
+    };
+    const csv = arrivalsToCsv([tricky]);
+    const [, dataRow] = csv.split('\r\n');
+    expect(dataRow).toMatch(/^ARR-001,"MV ""Lucky""",/);
+  });
+
+  test('uses CRLF line endings (RFC 4180)', () => {
+    const csv = arrivalsToCsv([baseArrival]);
+    expect(csv).toContain('\r\n');
+    // No bare LF line endings
+    expect(csv.replace(/\r\n/g, '')).not.toContain('\n');
+  });
+});

--- a/tests/routes.test.js
+++ b/tests/routes.test.js
@@ -343,3 +343,88 @@ describe('static dashboard', () => {
     expect(res.text).toContain('TideLog');
   });
 });
+
+describe('GET /api/arrivals/export.csv', () => {
+  test('returns 200 with text/csv content-type', async () => {
+    const res = await request(app).get('/api/arrivals/export.csv');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/csv');
+  });
+
+  test('sets a Content-Disposition attachment header with a dated filename', async () => {
+    const res = await request(app).get('/api/arrivals/export.csv');
+    const disposition = res.headers['content-disposition'];
+    expect(disposition).toMatch(/^attachment; filename="/);
+    // filename should be arrivals-YYYY-MM-DD.csv
+    expect(disposition).toMatch(/arrivals-\d{4}-\d{2}-\d{2}\.csv"/);
+  });
+
+  test('returns only the header row when the log is empty', async () => {
+    const res = await request(app).get('/api/arrivals/export.csv');
+    const lines = res.text.split('\r\n');
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toBe(
+      'id,vesselName,vesselType,lengthM,draftM,imo,eta,status,berthId,berthFrom,berthTo,loggedAt,arrivedAt'
+    );
+  });
+
+  test('returns one data row per logged arrival', async () => {
+    await request(app).post('/api/arrivals').send(validManifest());
+    await request(app)
+      .post('/api/arrivals')
+      .send(validManifest({ vesselName: 'Selkie', vesselType: 'fishing', imo: undefined }));
+
+    const res = await request(app).get('/api/arrivals/export.csv');
+    const lines = res.text.split('\r\n');
+    // header + 2 data rows
+    expect(lines).toHaveLength(3);
+    expect(lines[1]).toContain('MV Northern Star');
+    expect(lines[2]).toContain('Selkie');
+  });
+
+  test('data row contains vessel name, type, dimensions, ETA, and status', async () => {
+    await request(app).post('/api/arrivals').send(validManifest());
+
+    const res = await request(app).get('/api/arrivals/export.csv');
+    const [, dataRow] = res.text.split('\r\n');
+    expect(dataRow).toContain('MV Northern Star');
+    expect(dataRow).toContain('cargo');
+    expect(dataRow).toContain('85');
+    expect(dataRow).toContain('6.2');
+    expect(dataRow).toContain('2026-03-01T14:00:00.000Z');
+    expect(dataRow).toContain('expected');
+    expect(dataRow).toContain('IMO 9074729');
+  });
+
+  test('data row includes berth columns after assignment', async () => {
+    const { body } = await request(app).post('/api/arrivals').send(validManifest());
+    await request(app)
+      .post(`/api/arrivals/${body.arrival.id}/assign-berth`)
+      .send({ from: '2026-03-01T14:00:00Z', to: '2026-03-01T22:00:00Z' });
+
+    const res = await request(app).get('/api/arrivals/export.csv');
+    const [, dataRow] = res.text.split('\r\n');
+    expect(dataRow).toContain('B1');
+    expect(dataRow).toContain('2026-03-01T14:00:00.000Z');
+    expect(dataRow).toContain('2026-03-01T22:00:00.000Z');
+  });
+
+  test('data row includes arrivedAt timestamp after the vessel arrives', async () => {
+    const { body } = await request(app).post('/api/arrivals').send(validManifest());
+    await request(app)
+      .post(`/api/arrivals/${body.arrival.id}/arrive`)
+      .send({ time: '2026-03-01T15:30:00Z' });
+
+    const res = await request(app).get('/api/arrivals/export.csv');
+    const [, dataRow] = res.text.split('\r\n');
+    expect(dataRow).toContain('arrived');
+    expect(dataRow).toContain('2026-03-01T15:30:00.000Z');
+  });
+
+  test('uses CRLF line endings throughout the document', async () => {
+    await request(app).post('/api/arrivals').send(validManifest());
+    const res = await request(app).get('/api/arrivals/export.csv');
+    // Strip CRLF pairs; no bare LF should remain
+    expect(res.text.replace(/\r\n/g, '')).not.toContain('\n');
+  });
+});


### PR DESCRIPTION
🤖 Autonomously implemented by the agentic harness. Every change in this PR was verified against the repo's real build/test gate (`npm ci && npm run lint && npm run format:check && npx jest --passWithNoTests`) before the PR was opened.

### Summary

All 110 tests pass, lint is clean, and formatting is correct. Here's a summary of everything that was done:

---

## Summary

### What was implemented (SVD-4)

**`GET /api/arrivals/export.csv`** — returns the current arrival log as a properly formatted CSV file with a `Content-Disposition: attachment` header.

---

### Files changed

#### `lib/csv.js` *(new)*
A small RFC 4180-compliant CSV utility module with three exported functions:
- **`escapeCsvField(value)`** — handles `null`/`undefined` → empty string, wraps in double-quotes if the value contains `,`, `"`, `\n`, or `\r`, and escapes internal double-quotes by doubling them (`""`).
- **`toCsvRow(fields)`** — maps a field array through `escapeCsvField` and joins with commas.
- **`arrivalsToCsv(arrivals)`** — builds the complete CSV document (header row + one data row per arrival) using CRLF line endings as per RFC 4180.

The 13 columns emitted are: `id`, `vesselName`, `vesselType`, `lengthM`, `draftM`, `imo`, `eta`, `status`, `berthId`, `berthFrom`, `berthTo`, `loggedAt`, `arrivedAt`.

#### `routes/arrivals.js` *(modified)*
Added the `GET /export.csv` route **before** the `/:id` wildcard so it isn't consumed as an ID lookup. The handler:
- Reads all arrivals from the in-memory store (decorated with berth info via the existing `withBerth` helper).
- Builds the CSV using `arrivalsToCsv`.
- Sets `Content-Type: text/csv; charset=utf-8`.
- Sets `Content-Disposition: attachment; filename="arrivals-YYYY-MM-DD.csv"` with today's date, so the browser/curl suggests a meaningful filename for archiving.

#### `tests/csv.test.js` *(new)*
Unit tests for `lib/csv.js` covering: null/undefined handling, plain passthrough, comma-quoting, double-quote doubling, newline/CR wrapping, row joining, CRLF line endings, and the full `arrivalsToCsv` pipeline including empty logs, berth columns, and tricky vessel names.

#### `tests/routes.test.js` *(modified)*
Added a `GET /api/arrivals/export.csv` integration describe block with 8 tests covering: HTTP 200 status, `text/csv` content-type, dated `Content-Disposition` header, empty-log (header only), one-row-per-arrival count, all required field values in data rows, berth columns after assignment, `arrivedAt` after marking arrived, and CRLF line endings.

### Ticket

**[SVD-4]** CSV export of the day's log

Add {{GET /api/arrivals/export.csv}} returning the current log as CSV (one row per arrival: vessel, type, dimensions, ETA, status, berth, timestamps) with a proper {{Content-Disposition}} header, so the harbor office can archive the day sheet. Escape commas and quotes correctly.

### Files changed

```
lib/csv.js           |  96 ++++++++++++++++++++++++++++++++++++
 routes/arrivals.js   |  23 +++++++++
 tests/csv.test.js    | 136 +++++++++++++++++++++++++++++++++++++++++++++++++++
 tests/routes.test.js |  85 ++++++++++++++++++++++++++++++++
 4 files changed, 340 insertions(+)
```