### PR TITLE
feat: host the public demo on App Runner, read-only

### DIFF
--- a/apprunner.yaml
+++ b/apprunner.yaml
@@ -1,0 +1,27 @@
+# AWS App Runner source configuration for the public demo at demo.shipvane.com.
+#
+# Source-based (not a container image) on purpose: App Runner rebuilds and
+# redeploys on every push to main, so a feature Shipvane's Engine merges is
+# live on the demo minutes later without any release step. That auto-updating
+# behaviour is the point of the demo.
+#
+# The store is in-memory (routes/db.js) and re-seeds on boot, so every deploy
+# resets the harbor to a clean, populated state — no database, no backups,
+# nothing to leak.
+version: 1.0
+runtime: nodejs18
+build:
+  commands:
+    build:
+      - npm ci --omit=dev
+run:
+  runtime-version: 20
+  command: node server.js
+  network:
+    port: 8080
+  env:
+    - name: PORT
+      value: '8080'
+    # Public demo: reject writes. See the guard in server.js.
+    - name: TIDELOG_READ_ONLY
+      value: 'true'

--- a/server.js
+++ b/server.js
@@ -13,6 +13,21 @@ const app = express();
 
 app.use(express.json());
 
+// The public demo at demo.shipvane.com runs read-only: the store is in-memory
+// and shared by every visitor, so one person's writes would show up in
+// everyone else's harbor until the next restart. Off by default — local dev
+// and the tests get the full read/write app.
+if (process.env.TIDELOG_READ_ONLY === 'true') {
+  const WRITE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+  app.use('/api', (req, res, next) => {
+    if (!WRITE_METHODS.has(req.method)) return next();
+    res.status(403).json({
+      error: 'read_only',
+      message: 'This is a public read-only demo of TideLog. Clone the repo to run a writable copy.',
+    });
+  });
+}
+
 app.get('/api/health', (req, res) => {
   res.json({ status: 'ok', service: 'tidelog' });
 });

--- a/tests/readonly.test.js
+++ b/tests/readonly.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * The public demo runs with TILDELOG_READ_ONLY set; these lock in that reads
+ * still work and writes are refused. server.js reads the env var at require
+ * time, so each case loads a fresh module registry.
+ */
+
+const request = require('supertest');
+
+function loadApp(readOnly) {
+  jest.resetModules();
+  if (readOnly) {
+    process.env.TIDELOG_READ_ONLY = 'true';
+  } else {
+    delete process.env.TIDELOG_READ_ONLY;
+  }
+  return require('../server');
+}
+
+afterEach(() => {
+  delete process.env.TIDELOG_READ_ONLY;
+});
+
+describe('read-only demo mode', () => {
+  test('reads still work', async () => {
+    const app = loadApp(true);
+    await request(app).get('/api/health').expect(200);
+    await request(app).get('/api/berths').expect(200);
+  });
+
+  test('writes are refused with a useful message', async () => {
+    const app = loadApp(true);
+    const res = await request(app).post('/api/arrivals').send({ vessel: 'MV Test' });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('read_only');
+    expect(res.body.message).toMatch(/read-only demo/i);
+  });
+
+  test('off by default — the app stays writable for local dev and tests', async () => {
+    const app = loadApp(false);
+    const res = await request(app).post('/api/arrivals').send({ vessel: 'MV Test' });
+    expect(res.status).not.toBe(403);
+  });
+});


### PR DESCRIPTION
TideLog becomes the live demo at **demo.shipvane.com**. The MCP server that currently holds that subdomain moves to `mcp.shipvane.com` (see shipvane/engine#70), which also makes it consistent with every other board — raisepunch, lazycreatorengine, and pitchvault all serve MCP at `mcp.<domain>`.

## Source-based, not a container image

Deliberate: App Runner rebuilds and redeploys on every push to `main`, so a feature Engine merges is live on the demo minutes later with no release step. **A demo that visibly grows on its own is the entire point** — it's the marketing asset.

## Read-only, env-gated

`TIDELOG_READ_ONLY` is set only in `apprunner.yaml`. The store is in-memory and shared by every visitor, so one person's writes would appear in everyone else's harbor until the next restart. Writes get a 403 with a message pointing at the repo.

The guard is **off by default**, so local dev and the test suite keep the full read/write app — no forked behaviour.

## No database

`routes/db.js` re-seeds on boot, so every deploy resets to a clean, populated harbor. Nothing to provision, nothing to back up, nothing to leak — and the demo can never drift into looking empty or junked-up.

## Verification

`npx jest` — 88 pass (3 new covering reads-still-work, writes-refused, and off-by-default). `eslint` and `prettier --check` clean.

## Deploy order

Don't merge-and-forget: `demo.shipvane.com` is still bound to the MCP server's App Runner service. That association has to be released **after** `mcp.shipvane.com` is verified serving, or the demo board goes dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)