### PR TITLE
[11] Dashboard filter by vessel type

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -133,10 +133,24 @@ function renderWindows(windows) {
   }
 }
 
+function getTypeFilter() {
+  return document.getElementById('type-filter').value;
+}
+
+function buildArrivalsUrl() {
+  const type = getTypeFilter();
+  let url = '/api/arrivals';
+  if (type) {
+    url += `?type=${encodeURIComponent(type)}`;
+  }
+  return url;
+}
+
 async function refresh() {
   try {
+    const arrivalsUrl = buildArrivalsUrl();
     const [arrivalsRes, berthsRes, windowsRes] = await Promise.all([
-      fetchJson('/api/arrivals'),
+      fetchJson(arrivalsUrl),
       fetchJson('/api/berths'),
       fetchJson(`/api/tides/windows?draftM=${REFERENCE_DRAFT_M}`),
     ]);
@@ -161,6 +175,10 @@ async function refresh() {
 function tickClock() {
   document.getElementById('clock').textContent = timeFmt.format(new Date());
 }
+
+document.getElementById('type-filter').addEventListener('change', () => {
+  refresh();
+});
 
 tickClock();
 setInterval(tickClock, 1000);

--- a/public/index.html
+++ b/public/index.html
@@ -55,6 +55,20 @@
         <section class="panel" aria-labelledby="arrivals-heading">
           <div class="panel-head">
             <h2 id="arrivals-heading">Arrivals log</h2>
+            <div class="panel-controls">
+              <label for="type-filter">Filter by type:</label>
+              <select id="type-filter">
+                <option value="">All types</option>
+                <option value="cargo">Cargo</option>
+                <option value="container">Container</option>
+                <option value="tanker">Tanker</option>
+                <option value="fishing">Fishing</option>
+                <option value="passenger">Passenger</option>
+                <option value="tug">Tug</option>
+                <option value="yacht">Yacht</option>
+                <option value="other">Other</option>
+              </select>
+            </div>
             <span class="panel-note" id="arrivals-count"></span>
           </div>
           <div class="table-wrap">

--- a/public/styles.css
+++ b/public/styles.css
@@ -192,12 +192,45 @@ body {
   gap: 1rem;
   padding: 0.85rem 1.1rem;
   border-bottom: 1px solid var(--line);
+  flex-wrap: wrap;
 }
 
 .panel-head h2 {
   margin: 0;
   font-size: 1rem;
   letter-spacing: 0.02em;
+}
+
+.panel-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.86rem;
+}
+
+.panel-controls label {
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.panel-controls select {
+  padding: 0.35rem 0.65rem;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  font-size: 0.86rem;
+  background: var(--paper);
+  color: var(--ink);
+  cursor: pointer;
+}
+
+.panel-controls select:hover {
+  border-color: var(--muted);
+}
+
+.panel-controls select:focus {
+  outline: 2px solid var(--teal);
+  outline-offset: -2px;
 }
 
 .panel-note {

--- a/routes/arrivals.js
+++ b/routes/arrivals.js
@@ -2,7 +2,7 @@
 
 const express = require('express');
 
-const { normalizeManifest } = require('../lib/manifest');
+const { normalizeManifest, VESSEL_TYPES } = require('../lib/manifest');
 const { findBerth } = require('../lib/berths');
 const db = require('./db');
 
@@ -24,12 +24,22 @@ function withBerth(arrival) {
   };
 }
 
-/** List arrivals, optionally filtered by ?status=expected|arrived. */
+/** List arrivals, optionally filtered by ?status=expected|arrived and/or ?type=<vesselType>. */
 router.get('/', (req, res) => {
   let arrivals = [...db.state.arrivals.values()];
+
   if (req.query.status) {
     arrivals = arrivals.filter((a) => a.status === req.query.status);
   }
+
+  if (req.query.type) {
+    const type = req.query.type.toLowerCase().trim();
+    if (!VESSEL_TYPES.includes(type)) {
+      return res.status(400).json({ error: `type must be one of: ${VESSEL_TYPES.join(', ')}` });
+    }
+    arrivals = arrivals.filter((a) => a.vesselType === type);
+  }
+
   res.json({ arrivals: arrivals.map(withBerth) });
 });
 

--- a/tests/routes.test.js
+++ b/tests/routes.test.js
@@ -87,6 +87,65 @@ describe('/api/arrivals', () => {
     expect(expected.body.arrivals).toHaveLength(1);
   });
 
+  test('GET ?type= filters by vessel type', async () => {
+    await request(app)
+      .post('/api/arrivals')
+      .send(validManifest({ vesselType: 'cargo' }));
+    await request(app)
+      .post('/api/arrivals')
+      .send(validManifest({ vesselName: 'Selkie', vesselType: 'fishing', imo: undefined }));
+    await request(app)
+      .post('/api/arrivals')
+      .send(validManifest({ vesselName: 'Tarn Voyager', vesselType: 'tanker', imo: undefined }));
+
+    const tankers = await request(app).get('/api/arrivals?type=tanker');
+    expect(tankers.status).toBe(200);
+    expect(tankers.body.arrivals).toHaveLength(1);
+    expect(tankers.body.arrivals[0].vesselName).toBe('Tarn Voyager');
+    expect(tankers.body.arrivals[0].vesselType).toBe('tanker');
+
+    const fishing = await request(app).get('/api/arrivals?type=fishing');
+    expect(fishing.status).toBe(200);
+    expect(fishing.body.arrivals).toHaveLength(1);
+    expect(fishing.body.arrivals[0].vesselName).toBe('Selkie');
+  });
+
+  test('GET ?type= is case-insensitive', async () => {
+    await request(app)
+      .post('/api/arrivals')
+      .send(validManifest({ vesselName: 'Selkie', vesselType: 'fishing', imo: undefined }));
+
+    const lower = await request(app).get('/api/arrivals?type=fishing');
+    const upper = await request(app).get('/api/arrivals?type=FISHING');
+    const mixed = await request(app).get('/api/arrivals?type=FiShInG');
+
+    expect(lower.body.arrivals).toHaveLength(1);
+    expect(upper.body.arrivals).toHaveLength(1);
+    expect(mixed.body.arrivals).toHaveLength(1);
+  });
+
+  test('GET ?type= returns 400 for invalid vessel type', async () => {
+    const res = await request(app).get('/api/arrivals?type=submarine');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('type must be one of');
+    expect(res.body.error).toContain('cargo');
+    expect(res.body.error).toContain('tanker');
+  });
+
+  test('GET ?type= and ?status= can be combined', async () => {
+    const { body: cargo1 } = await request(app).post('/api/arrivals').send(validManifest());
+    await request(app)
+      .post('/api/arrivals')
+      .send(validManifest({ vesselName: 'Selkie', vesselType: 'fishing', imo: undefined }));
+    await request(app).post(`/api/arrivals/${cargo1.arrival.id}/arrive`).send({});
+
+    const result = await request(app).get('/api/arrivals?type=cargo&status=arrived');
+    expect(result.status).toBe(200);
+    expect(result.body.arrivals).toHaveLength(1);
+    expect(result.body.arrivals[0].vesselType).toBe('cargo');
+    expect(result.body.arrivals[0].status).toBe('arrived');
+  });
+
   test('GET /:id returns one arrival and 404s on unknown ids', async () => {
     const { body } = await request(app).post('/api/arrivals').send(validManifest());
 


### PR DESCRIPTION
🤖 Autonomously implemented by the agentic harness. Every change in this PR was verified against the repo's real build/test gate (`npm ci && npm run lint && npm run format:check && npx jest --passWithNoTests`) before the PR was opened.

### Summary

Perfect! Let me create a summary of the changes:

## Summary

I have successfully implemented **Ticket 11: Dashboard filter by vessel type** with the following changes:

### Backend Changes (API)

**File: `routes/arrivals.js`**
- Added `VESSEL_TYPES` import from the manifest module
- Added support for `?type=<vesselType>` query parameter to the `GET /api/arrivals` endpoint
- Validation: Returns 400 with a helpful error message if an invalid vessel type is provided
- Type filtering is case-insensitive (e.g., `?type=TANKER` works the same as `?type=tanker`)
- Filters can be combined with existing filters (e.g., `?type=tanker&status=arrived`)

### Frontend Changes (Dashboard UI)

**File: `public/index.html`**
- Added a type filter dropdown (`<select id="type-filter">`) in the "Arrivals log" panel header
- Options include all 8 vessel types: cargo, container, tanker, fishing, passenger, tug, yacht, other
- Plus an "All types" option to show all arrivals

**File: `public/app.js`**
- Added `getTypeFilter()` function to retrieve the selected type from the dropdown
- Added `buildArrivalsUrl()` function to construct the API URL with the selected type parameter
- Modified `refresh()` function to use the filtered URL when fetching arrivals
- Added event listener to the type filter dropdown to trigger a refresh when the selection changes
- **Stat tiles now automatically reflect filtered data**: When a type is selected, the "Vessels expected" and "Vessels in port" counts show only arrivals of that type

**File: `public/styles.css`**
- Added `.panel-controls` styling for the filter control container
- Added styling for the filter label and select dropdown with hover and focus states

### Tests Added

**File: `tests/routes.test.js`**
- Test: `GET ?type= filters by vessel type` - Verifies filtering works correctly
- Test: `GET ?type= is case-insensitive` - Verifies case-insensitive handling
- Test: `GET ?type= returns 400 for invalid vessel type` - Verifies error handling
- Test: `GET ?type= and ?status= can be combined` - Verifies filter combination

### Verification
✅ All 96 tests passing  
✅ Linting: No errors  
✅ Code formatting: Prettier compliant  
✅ Type filter implemented with validation  
✅ UI dropdown added and styled  
✅ Stats tiles respect the filter  
✅ Combined filters work correctly (type + status)

### Ticket

**[11]** Dashboard filter by vessel type

Let `GET /api/arrivals` accept `?type=tanker` (validated against the known vessel types, 400 on junk) and add a type dropdown to the dashboard that re-fetches the arrivals table with the filter applied. Counts in the stat tiles should follow the filter.

<!-- ported from SVD-7 on 2026-08-19 -->

### Files changed

```
public/app.js        | 20 +++++++++++++++++-
 public/index.html    | 14 +++++++++++++
 public/styles.css    | 33 +++++++++++++++++++++++++++++
 routes/arrivals.js   | 14 +++++++++++--
 tests/routes.test.js | 59 ++++++++++++++++++++++++++++++++++++++++++++++++++++
 5 files changed, 137 insertions(+), 3 deletions(-)
```