### PR TITLE
[28] Show a relative countdown for when a tide window opens

### DIFF
--- a/lib/tides.js
+++ b/lib/tides.js
@@ -11,6 +11,11 @@
  * is met, using linear interpolation between table entries.
  */
 
+const dayjs = require('dayjs');
+const relativeTime = require('dayjs/plugin/relativeTime');
+
+dayjs.extend(relativeTime);
+
 const DEFAULT_SAFETY_MARGIN_M = 0.5;
 
 function toMillis(value, label = 'time') {
@@ -128,10 +133,32 @@ function safeWindows(entries, constraints) {
     }));
 }
 
+/**
+ * Human-readable countdown for when a tide window opens relative to a reference time.
+ *
+ * Returns a short relative label like "in 2 hours", "in 25 minutes", or "3 hours ago"
+ * for the window's start time relative to the reference time.
+ *
+ * @param {Object} window - A tide window object with a `start` property (ISO-8601 string).
+ * @param {Date|string} now - Reference time for the countdown. Defaults to current time.
+ * @returns {string} A human-readable relative time label.
+ */
+function describeWindowStart(window, now) {
+  if (!window || typeof window.start !== 'string') {
+    throw new TypeError('window must have a start property with a valid ISO-8601 timestamp');
+  }
+
+  const referenceTime = now ? dayjs(now) : dayjs();
+  const startTime = dayjs(window.start);
+
+  return startTime.from(referenceTime);
+}
+
 module.exports = {
   DEFAULT_SAFETY_MARGIN_M,
   requiredTideHeight,
   heightAt,
   isSafeAt,
   safeWindows,
+  describeWindowStart,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "dayjs": "^1.11.23",
         "express": "^4.21.2"
       },
       "devDependencies": {
@@ -2065,6 +2066,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.23",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+      "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "dayjs": "^1.11.23",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/tides.test.js
+++ b/tests/tides.test.js
@@ -6,6 +6,7 @@ const {
   heightAt,
   isSafeAt,
   safeWindows,
+  describeWindowStart,
 } = require('../lib/tides');
 
 /** Hourly ramp: 0m at 00:00 rising to 3m at 03:00, back to 0m at 06:00. */
@@ -179,5 +180,43 @@ describe('safeWindows', () => {
         { draftM: 6, channelDepthM: 6 }
       )
     ).toThrow(TypeError);
+  });
+});
+
+describe('describeWindowStart', () => {
+  const referenceTime = '2026-03-01T12:00:00Z';
+
+  test('returns a countdown for a window opening in the future', () => {
+    const window = { start: '2026-03-01T14:00:00Z', end: '2026-03-01T15:00:00Z' };
+    const description = describeWindowStart(window, referenceTime);
+    expect(description).toBe('in 2 hours');
+  });
+
+  test('returns a past countdown for a window that already opened', () => {
+    const window = { start: '2026-03-01T10:00:00Z', end: '2026-03-01T11:00:00Z' };
+    const description = describeWindowStart(window, referenceTime);
+    expect(description).toBe('2 hours ago');
+  });
+
+  test('handles minutes in the future', () => {
+    const window = { start: '2026-03-01T12:25:00Z', end: '2026-03-01T13:00:00Z' };
+    const description = describeWindowStart(window, referenceTime);
+    expect(description).toBe('in 25 minutes');
+  });
+
+  test('handles minutes in the past', () => {
+    const window = { start: '2026-03-01T11:35:00Z', end: '2026-03-01T12:00:00Z' };
+    const description = describeWindowStart(window, referenceTime);
+    expect(description).toBe('25 minutes ago');
+  });
+
+  test('throws for missing window object', () => {
+    expect(() => describeWindowStart(null, referenceTime)).toThrow(TypeError);
+    expect(() => describeWindowStart(undefined, referenceTime)).toThrow(TypeError);
+  });
+
+  test('throws for window without start property', () => {
+    const window = { end: '2026-03-01T15:00:00Z' };
+    expect(() => describeWindowStart(window, referenceTime)).toThrow(TypeError);
   });
 });


### PR DESCRIPTION
🤖 Autonomously implemented by the agentic harness. Every change in this PR was verified against the repo's real build/test gate (`npm ci && npm run lint && npm run format:check && npx jest --passWithNoTests`) before the PR was opened.

### Summary

Perfect! Now let me create a summary of what I've implemented:

## Summary

I have successfully implemented ticket 28: **Show a relative countdown for when a tide window opens**. Here's what was done:

### Changes Made:

1. **Updated `package.json`**:
   - Added `dayjs` (v1.11.23) as a production dependency
   - Updated `package-lock.json` to reflect the new dependency

2. **Enhanced `lib/tides.js`**:
   - Imported `dayjs` and its `relativeTime` plugin
   - Added a new `describeWindowStart(window, now)` function that:
     - Takes a tide window object with a `start` ISO-8601 timestamp
     - Takes an optional `now` parameter for reference time (defaults to current time if not supplied)
     - Returns a human-readable relative time label like "in 2 hours", "25 minutes ago", etc.
     - Uses dayjs's relativeTime plugin for proper pluralization and formatting
     - Validates inputs and throws TypeError if window or start are missing
   - Exported the new function alongside existing tide functions

3. **Added comprehensive tests in `tests/tides.test.js`**:
   - Tests for future windows ("in 2 hours", "in 25 minutes")
   - Tests for past windows ("2 hours ago", "25 minutes ago")
   - Tests for missing or invalid inputs (null, undefined, missing start property)
   - Tests use pinned `now` values for stable, deterministic assertions
   - All existing tide tests remain unchanged and passing

### Acceptance Criteria Met:
✅ `describeWindowStart` is exported from `lib/tides.js`  
✅ Covered in `tests/tides.test.js` with `now` pinned for stable assertions  
✅ Future windows read as "in ..."  
✅ Past windows read as "... ago"  
✅ Existing tide-window behavior is unchanged (all existing tests pass)  
✅ Full gate command passes: `npm ci && npm run lint && npm run format:check && npx jest --passWithNoTests`

### Files Modified:
- `package.json` - Added dayjs dependency
- `package-lock.json` - Regenerated with dayjs
- `lib/tides.js` - Added describeWindowStart function
- `tests/tides.test.js` - Added comprehensive tests for new function

### Ticket

**[28]** Show a relative countdown for when a tide window opens

Tide windows are returned as absolute timestamps, which is the right thing for
the API but hard to read at a glance when the harbour master is deciding what to
do in the next hour. Add a human-readable countdown alongside the absolute time.

**What to build**

In `lib/tides.js`, add and export a `describeWindowStart(window, now)` helper
that returns a short relative label for when a tide window opens — "in 2 hours",
"in 25 minutes", "3 hours ago" — given the window and a reference time.

Use **dayjs** with its `relativeTime` plugin for the formatting. Don't hand-roll
the pluralisation and rounding; that's exactly the kind of thing a library
already gets right, and we'll want the same formatting elsewhere later.

`now` should default to the current time when not supplied, so callers in tests
can pin it deterministically.

**Acceptance**

- `describeWindowStart` is exported from `lib/tides.js` and covered in
  `tests/tides.test.js`, with `now` pinned so the assertions are stable.
- A window opening in the future reads as "in ...", one that already opened
  reads as "... ago".
- The existing tide-window behaviour is unchanged — this is additive.
- `npm ci && npm run lint && npm run format:check && npx jest` is green.

### Files changed

```
lib/tides.js        | 27 +++++++++++++++++++++++++++
 package-lock.json   |  7 +++++++
 package.json        |  1 +
 tests/tides.test.js | 39 +++++++++++++++++++++++++++++++++++++++
 4 files changed, 74 insertions(+)
```